### PR TITLE
Path stuff, make mkdir work when parents are absent

### DIFF
--- a/driver.py
+++ b/driver.py
@@ -1,4 +1,4 @@
-import json, os, time
+import json, os, time, pathlib
 import cppimport
 import cppimport.import_hook
 cppimport.settings["use_filelock"] = False
@@ -26,13 +26,13 @@ class TestBenchmarkSuite:
 
     def run(self, tp_implementations, correctness=True):
         millis_since_epoch = round(time.time() * 1000)
-        output_folder = f'outputs/{millis_since_epoch}'
-        os.mkdir(output_folder)
+        output_folder = pathlib.Path(f'outputs/{millis_since_epoch}')
+        output_folder.mkdir(parents=True)
         metadata = {
             "configs": self.configs,
             "implementations": [impl.name() for impl in tp_implementations]
         }
-        with open(f'{output_folder}/metadata.json', 'w') as f:
+        with open(os.path.join(output_folder,'metadata.json'), 'w') as f:
             json.dump(metadata, f) 
 
         for config in self.configs: 
@@ -62,7 +62,7 @@ class TestBenchmarkSuite:
                     "correctness": correctness,
                     "benchmark": benchmark
                 }
-                fname = f"{output_folder}/{L1}_{L2}_{L3}_{impl.name()}.json"
+                fname = pathlib.Path(f"{output_folder}/{L1}_{L2}_{L3}_{impl.name()}.json")
 
                 with open(fname, 'w') as f:
                     json.dump(result, f, indent=2)

--- a/src/implementations/TensorProduct.py
+++ b/src/implementations/TensorProduct.py
@@ -1,4 +1,4 @@
-import pickle
+import pickle, pathlib
 import numpy as np
 import numpy.linalg as la
 
@@ -31,7 +31,7 @@ class TensorProduct:
         return self.internal.get_row_length(mode)
 
     def load_cg_tensor(self, l1, l2, l3):
-        with open("data/CG_tensors.pickle", 'rb') as f:
+        with open(pathlib.Path("data/CG_tensors.pickle"), 'rb') as f:
             tensors = pickle.load(f) 
             return tensors[(l1, l2, l3)]
 


### PR DESCRIPTION
when you download the repo fresh, it errors because it can't create the output folder. I fixed that by using pathlib 