### PR TITLE
Compile bugfix for PT2.7

### DIFF
--- a/openequivariance/extension/libtorch_tp_jit.cpp
+++ b/openequivariance/extension/libtorch_tp_jit.cpp
@@ -111,6 +111,10 @@ public:
             reinterpret_cast<void*>(L3_grad)
         );
     }
+
+    int64_t get_L3_dim() const {
+        return L3_dim;
+    }
 };
 
 torch::Tensor jit_tp_forward(
@@ -425,6 +429,7 @@ TORCH_LIBRARY_FRAGMENT(libtorch_tp_jit, m) {
         .def("__len__", [](const c10::intrusive_ptr<TorchJITProduct>& test) -> int64_t {
             return 0;
         })
+        .def("get_L3_dim", &TorchJITProduct::get_L3_dim)
         .def_pickle(
             // __getstate__
             [](const c10::intrusive_ptr<TorchJITProduct>& self)

--- a/openequivariance/extension/libtorch_tp_jit.cpp
+++ b/openequivariance/extension/libtorch_tp_jit.cpp
@@ -285,6 +285,10 @@ public:
             reinterpret_cast<void*>(workspace),
             reinterpret_cast<void*>(transpose_perm));
     }
+
+    int64_t get_L3_dim() const {
+        return L3_dim;
+    }
 };
 
 torch::Tensor jit_conv_forward(
@@ -455,6 +459,7 @@ TORCH_LIBRARY_FRAGMENT(libtorch_tp_jit, m) {
         .def("__len__", [](const c10::intrusive_ptr<TorchJITConv>& test) -> int64_t {
             return 0;
         })
+        .def("get_L3_dim", &TorchJITConv::get_L3_dim)
         .def_pickle(
             // __getstate__
             [](const c10::intrusive_ptr<TorchJITConv>& self)

--- a/openequivariance/implementations/LoopUnrollTP.py
+++ b/openequivariance/implementations/LoopUnrollTP.py
@@ -200,9 +200,13 @@ class LoopUnrollTP(TensorProductBase):
 
         @torch.library.register_fake("libtorch_tp_jit::jit_tp_forward")
         def fake_forward(jit, L1_in, L2_in, W):
-            return L1_in.new_empty(
-                L1_in.shape[0], jit.wrapped_obj.kernel_dims["L3_dim"]
-            )
+            L3_dim = None
+            if hasattr(jit, "wrapped_obj"):
+                L3_dim = jit.wrapped_obj.kernel_dims["L3_dim"]
+            else:
+                L3_dim = jit.get_L3_dim()
+
+            return L1_in.new_empty(L1_in.shape[0], L3_dim)
 
         @torch.library.register_fake("libtorch_tp_jit::jit_tp_backward")
         def fake_backward(jit, L1_in, L2_in, W, L3_grad):

--- a/openequivariance/implementations/convolution/LoopUnrollConv.py
+++ b/openequivariance/implementations/convolution/LoopUnrollConv.py
@@ -285,9 +285,13 @@ class LoopUnrollConv(ConvolutionBase):
         def fake_forward(
             jit, L1_in, L2_in, W, rows, cols, workspace_buffer, sender_perm
         ):
-            return L1_in.new_empty(
-                L1_in.shape[0], jit.wrapped_obj.kernel_dims["L3_dim"]
-            )
+            L3_dim = None
+            if hasattr(jit, "wrapped_obj"):
+                L3_dim = jit.wrapped_obj.kernel_dims["L3_dim"]
+            else:
+                L3_dim = jit.get_L3_dim()
+
+            return L1_in.new_empty(L1_in.shape[0], L3_dim)
 
         @torch.library.register_fake("libtorch_tp_jit::jit_conv_backward")
         def fake_backward(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,7 @@ bench = [
 ]
 
 dev = [
+  "e3nn",
   "pre-commit",
   "ruff",
   "pytest",

--- a/tests/export_test.py
+++ b/tests/export_test.py
@@ -100,6 +100,15 @@ def test_jitscript(tp_and_inputs):
     assert torch.allclose(uncompiled_result, compiled_result, atol=1e-5)
 
 
+def test_compile(tp_and_inputs):
+    tp, inputs = tp_and_inputs
+    uncompiled_result = tp.forward(*inputs)
+
+    compiled_tp = torch.compile(tp) 
+    compiled_result = compiled_tp(*inputs)
+    assert torch.allclose(uncompiled_result, compiled_result, atol=1e-5)
+
+
 def test_export(tp_and_inputs):
     tp, inputs = tp_and_inputs
     uncompiled_result = tp.forward(*inputs)

--- a/tests/export_test.py
+++ b/tests/export_test.py
@@ -104,7 +104,7 @@ def test_compile(tp_and_inputs):
     tp, inputs = tp_and_inputs
     uncompiled_result = tp.forward(*inputs)
 
-    compiled_tp = torch.compile(tp) 
+    compiled_tp = torch.compile(tp)
     compiled_result = compiled_tp(*inputs)
     assert torch.allclose(uncompiled_result, compiled_result, atol=1e-5)
 


### PR DESCRIPTION
PT2.7 passes Torchbind ScriptObjects directly instead of the fake objects during tracing. Guarded the fake function L3_dim  field with "hasattr" and added a new function to C++ backend to avoid this.