### PR TITLE
Directly import sysconfig + Remove Multidevice "Memory Leak"

### DIFF
--- a/openequivariance/extension/util/backend_cuda.hpp
+++ b/openequivariance/extension/util/backend_cuda.hpp
@@ -168,7 +168,6 @@ public:
     CUJITKernel(string plaintext) :
         kernel_plaintext(plaintext) {
 
-        CUDA_ERRCHK(cudaFree(0)); // No-op to initialize the primary context 
         NVRTC_SAFE_CALL(
         nvrtcCreateProgram( &prog,                     // prog
                             kernel_plaintext.c_str(),  // buffer

--- a/openequivariance/extension/util/backend_hip.hpp
+++ b/openequivariance/extension/util/backend_hip.hpp
@@ -199,7 +199,6 @@ public:
     HIPJITKernel(string plaintext) :
         kernel_plaintext(plaintext) {
 
-        //HIP_ERRCHK(hipFree(0)); // No-op to initialize the primary context 
         HIPRTC_SAFE_CALL(
         hiprtcCreateProgram( &prog,                    // prog
                             kernel_plaintext.c_str(),  // buffer

--- a/openequivariance/extlib/__init__.py
+++ b/openequivariance/extlib/__init__.py
@@ -2,10 +2,10 @@
 import sys
 import os
 import warnings
+import sysconfig
 from pathlib import Path
 
 from openequivariance.benchmark.logging_utils import getLogger
-from distutils import sysconfig
 
 oeq_root = str(Path(__file__).parent.parent)
 

--- a/openequivariance/implementations/TensorProduct.py
+++ b/openequivariance/implementations/TensorProduct.py
@@ -96,7 +96,7 @@ class TensorProduct(torch.nn.Module, LoopUnrollTP):
                 weights.contiguous(),
             )
             L3_out = torch.empty(
-                (L1_in_c.shape[0], self.L3.dim), dtype=L1_in.dtype, device="cuda"
+                (L1_in_c.shape[0], self.L3.dim), dtype=L1_in.dtype, device=L1_in.device
             )
             self.forward_raw(
                 L1_in_c.shape[0],


### PR DESCRIPTION
distutils will be deprecated in future Python versions, hence the direct call. Calling cudaFree(0) when CUJITKernel is initiated initializes the primary context on device 0 for any process, leading to extra memory consumption on device 0 when multiple devices are used. CUDA contexts can take 0.4-1 GB, so this is nontrivial overhead that we are eliminating.