### PR TITLE
Make certain args kwarg-only, fix json bug

### DIFF
--- a/openequivariance/benchmark/plotting/plot_convolution.py
+++ b/openequivariance/benchmark/plotting/plot_convolution.py
@@ -11,6 +11,7 @@ from openequivariance.benchmark.plotting.plotting_utils import (
     dtype_labelmap,
     grouped_barchart,
     load_benchmarks,
+    filter_experiments
 )
 
 
@@ -42,7 +43,7 @@ def plot_convolution(data_folder):
             for graph in graphs:
                 data[direction][dtype][graph_lmap[graph]] = {}
                 for impl in implementations:
-                    exp = filter(
+                    exp = filter_experiments(
                         benchmarks,
                         {
                             "graph": graph,

--- a/openequivariance/benchmark/plotting/plot_convolution.py
+++ b/openequivariance/benchmark/plotting/plot_convolution.py
@@ -11,7 +11,7 @@ from openequivariance.benchmark.plotting.plotting_utils import (
     dtype_labelmap,
     grouped_barchart,
     load_benchmarks,
-    filter_experiments
+    filter_experiments,
 )
 
 

--- a/openequivariance/benchmark/plotting/plot_double_backward.py
+++ b/openequivariance/benchmark/plotting/plot_double_backward.py
@@ -7,6 +7,7 @@ from openequivariance.benchmark.plotting.plotting_utils import (
     labelmap,
     grouped_barchart,
     load_benchmarks,
+    filter_experiments
 )
 
 
@@ -32,7 +33,7 @@ def plot_double_backward(data_folder):
                     for b in benchmarks
                     if b["benchmark results"]["rep_dtype"] == "<class 'numpy.float32'>"
                 ]
-                exp = filter(
+                exp = filter_experiments(
                     f32_benches,
                     {
                         "config_label": desc,
@@ -54,7 +55,7 @@ def plot_double_backward(data_folder):
                     if "float64" in b["benchmark results"]["rep_dtype"]
                 ]
 
-                exp = filter(
+                exp = filter_experiments(
                     f64_benches,
                     {
                         "config_label": desc,

--- a/openequivariance/benchmark/plotting/plot_double_backward.py
+++ b/openequivariance/benchmark/plotting/plot_double_backward.py
@@ -7,7 +7,7 @@ from openequivariance.benchmark.plotting.plotting_utils import (
     labelmap,
     grouped_barchart,
     load_benchmarks,
-    filter_experiments
+    filter_experiments,
 )
 
 

--- a/openequivariance/benchmark/plotting/plot_roofline.py
+++ b/openequivariance/benchmark/plotting/plot_roofline.py
@@ -5,6 +5,7 @@ from openequivariance.benchmark.plotting.plotting_utils import (
     labelmap,
     load_benchmarks,
     roofline_plot,
+    filter_experiments,
 )
 
 
@@ -20,7 +21,7 @@ def plot_roofline(data_folder):
         for direction in ["forward", "backward"]:
             data[direction][desc] = {}
             for impl in implementations:
-                exp = filter(
+                exp = filter_experiments(
                     benchmarks,
                     {
                         "config_label": desc,

--- a/openequivariance/benchmark/plotting/plot_uvu.py
+++ b/openequivariance/benchmark/plotting/plot_uvu.py
@@ -7,7 +7,7 @@ from openequivariance.benchmark.plotting.plotting_utils import (
     labelmap,
     grouped_barchart,
     load_benchmarks,
-    filter_experiments
+    filter_experiments,
 )
 
 

--- a/openequivariance/benchmark/plotting/plot_uvu.py
+++ b/openequivariance/benchmark/plotting/plot_uvu.py
@@ -7,6 +7,7 @@ from openequivariance.benchmark.plotting.plotting_utils import (
     labelmap,
     grouped_barchart,
     load_benchmarks,
+    filter_experiments
 )
 
 
@@ -42,7 +43,7 @@ def plot_uvu(data_folder):
                     for b in benchmarks
                     if b["benchmark results"]["rep_dtype"] == "<class 'numpy.float32'>"
                 ]
-                exp = filter(
+                exp = filter_experiments(
                     f32_benches,
                     {
                         "config_label": desc,
@@ -66,7 +67,7 @@ def plot_uvu(data_folder):
                     for b in benchmarks
                     if b["benchmark results"]["rep_dtype"] == "<class 'numpy.float64'>"
                 ]
-                exp = filter(
+                exp = filter_experiments(
                     f64_benches,
                     {
                         "config_label": desc,

--- a/openequivariance/benchmark/plotting/plot_uvw.py
+++ b/openequivariance/benchmark/plotting/plot_uvw.py
@@ -8,6 +8,7 @@ from openequivariance.benchmark.plotting.plotting_utils import (
     grouped_barchart,
     calculate_tp_per_sec,
     load_benchmarks,
+    filter_experiments
 )
 
 
@@ -31,7 +32,7 @@ def plot_uvw(data_folder):
                         if b["benchmark results"]["rep_dtype"]
                         == "<class 'numpy.float32'>"
                     ]
-                    exp = filter(
+                    exp = filter_experiments(
                         f32_benches,
                         {
                             "config_label": desc,
@@ -54,7 +55,7 @@ def plot_uvw(data_folder):
                         if b["benchmark results"]["rep_dtype"]
                         == "<class 'numpy.float64'>"
                     ]
-                    exp = filter(
+                    exp = filter_experiments(
                         f64_benches,
                         {
                             "config_label": desc,

--- a/openequivariance/benchmark/plotting/plot_uvw.py
+++ b/openequivariance/benchmark/plotting/plot_uvw.py
@@ -8,7 +8,7 @@ from openequivariance.benchmark.plotting.plotting_utils import (
     grouped_barchart,
     calculate_tp_per_sec,
     load_benchmarks,
-    filter_experiments
+    filter_experiments,
 )
 
 

--- a/openequivariance/benchmark/plotting/plotting_utils.py
+++ b/openequivariance/benchmark/plotting/plotting_utils.py
@@ -64,7 +64,7 @@ def load_benchmarks(path: pathlib.Path):
     return benchmarks, metadata
 
 
-def filter(benchmarks, base, match_one=True):
+def filter_experiments(benchmarks, base, match_one=True):
     filtered_results = []
     for benchmark in benchmarks:
         matched = True

--- a/openequivariance/implementations/TensorProduct.py
+++ b/openequivariance/implementations/TensorProduct.py
@@ -16,7 +16,7 @@ class TensorProduct(torch.nn.Module, LoopUnrollTP):
     * The provided tensor product specification is unsupported.
 
     :param problem: Specification of the tensor product.
-    :param use_opaque: If ``True, uses an opaque forward pass that cannot be symbolically traced. *Default*: ``False``.
+    :param use_opaque: If ``True``, uses an opaque forward pass that cannot be symbolically traced. *Default*: ``False``.
     """
 
     def __init__(self, problem: TPProblem, torch_op=True, use_opaque=False):

--- a/openequivariance/implementations/convolution/CUEConv.py
+++ b/openequivariance/implementations/convolution/CUEConv.py
@@ -7,8 +7,8 @@ from openequivariance.implementations.convolution.ConvolutionBase import Convolu
 
 
 class CUEConv(ConvolutionBase):
-    def __init__(self, config, idx_dtype=np.int64, torch_op=True):
-        super().__init__(config, idx_dtype, torch_op)
+    def __init__(self, config, *, idx_dtype=np.int64, torch_op=True):
+        super().__init__(config, idx_dtype=idx_dtype, torch_op=torch_op)
 
         global torch
         import torch
@@ -32,8 +32,8 @@ class CUEConv(ConvolutionBase):
 
 
 class CUEConvFused(ConvolutionBase):
-    def __init__(self, config, idx_dtype=np.int64, torch_op=True):
-        super().__init__(config, idx_dtype, torch_op)
+    def __init__(self, config, *, idx_dtype=np.int64, torch_op=True):
+        super().__init__(config, idx_dtype=idx_dtype, torch_op=torch_op)
 
         global torch
         import torch

--- a/openequivariance/implementations/convolution/ConvolutionBase.py
+++ b/openequivariance/implementations/convolution/ConvolutionBase.py
@@ -87,7 +87,14 @@ class CoordGraph:
 class ConvolutionBase:
     next_conv_id = 0  # Used to assign unique IDs to each conv instance
 
-    def __init__(self, config, idx_dtype, torch_op=False, deterministic=False):
+    def __init__(
+        self,
+        config,
+        *,
+        idx_dtype: type[np.generic] = np.int64,
+        torch_op=False,
+        deterministic=False,
+    ):
         config = config.clone()
         self.config = config
         self.L1, self.L2, self.L3 = (
@@ -560,8 +567,8 @@ class ConvolutionBase:
 
         result = {
             "direction": direction,
-            "flops_per_tp": ops_per_tp,
-            "data_per_tp": data_per_tp,
+            "flops_per_tp": int(ops_per_tp),
+            "data_per_tp": int(data_per_tp),
             "time_millis": list(time_millis),
             "throughputs_gflops": list(throughputs_gflops),
             "bandwidth_gbps": list(bandwidth_gbps),

--- a/openequivariance/implementations/convolution/E3NNConv.py
+++ b/openequivariance/implementations/convolution/E3NNConv.py
@@ -5,9 +5,9 @@ from openequivariance.implementations.E3NNTensorProduct import E3NNTensorProduct
 
 
 class E3NNConv(ConvolutionBase):
-    def __init__(self, config, idx_dtype=np.int64, torch_op=True):
+    def __init__(self, config, *, idx_dtype=np.int64, torch_op=True):
         assert torch_op
-        super().__init__(config, idx_dtype, torch_op)
+        super().__init__(config, idx_dtype=idx_dtype, torch_op=torch_op)
 
         from e3nn import o3
         import torch

--- a/openequivariance/implementations/convolution/LoopUnrollConv.py
+++ b/openequivariance/implementations/convolution/LoopUnrollConv.py
@@ -22,12 +22,15 @@ class LoopUnrollConv(ConvolutionBase):
     def __init__(
         self,
         config,
-        idx_dtype=np.int64,
-        torch_op=False,
-        deterministic=False,
-        kahan=False,
+        *,
+        idx_dtype: type[np.generic] = np.int64,
+        torch_op: bool = False,
+        deterministic: bool = False,
+        kahan: bool = False,
     ):
-        super().__init__(config, idx_dtype, torch_op, deterministic)
+        super().__init__(
+            config, idx_dtype=idx_dtype, torch_op=torch_op, deterministic=deterministic
+        )
 
         if kahan:
             assert deterministic

--- a/openequivariance/implementations/convolution/TensorProductConv.py
+++ b/openequivariance/implementations/convolution/TensorProductConv.py
@@ -38,9 +38,10 @@ class TensorProductConv(torch.nn.Module, LoopUnrollConv):
     def __init__(
         self,
         problem: TPProblem,
+        *,
         deterministic: bool = False,
         kahan: bool = False,
-        torch_op=True,
+        torch_op: bool = True,
         use_opaque: bool = False,
     ):
         torch.nn.Module.__init__(self)
@@ -378,8 +379,8 @@ class TensorProductConv(torch.nn.Module, LoopUnrollConv):
 
 
 class TensorProductConvKahan(TensorProductConv):
-    def __init__(self, config, idx_dtype=np.int64, torch_op=True):
-        super().__init__(config, idx_dtype, torch_op, deterministic=True, kahan=True)
+    def __init__(self, config, *, torch_op=True):
+        super().__init__(config, torch_op=torch_op, deterministic=True, kahan=True)
 
     @staticmethod
     def name():
@@ -387,8 +388,8 @@ class TensorProductConvKahan(TensorProductConv):
 
 
 class TensorProductConvDeterministic(TensorProductConv):
-    def __init__(self, config, idx_dtype=np.int64, torch_op=True):
-        super().__init__(config, idx_dtype, torch_op, deterministic=True)
+    def __init__(self, config, *, torch_op=True):
+        super().__init__(config, torch_op=torch_op, deterministic=True)
 
     @staticmethod
     def name():
@@ -396,8 +397,8 @@ class TensorProductConvDeterministic(TensorProductConv):
 
 
 class TensorProductConvAtomic(TensorProductConv):
-    def __init__(self, config, idx_dtype=np.int64, torch_op=True):
-        super().__init__(config, idx_dtype, torch_op, deterministic=False)
+    def __init__(self, config, *, torch_op=True):
+        super().__init__(config, torch_op=torch_op, deterministic=False)
 
     @staticmethod
     def name():
@@ -405,12 +406,12 @@ class TensorProductConvAtomic(TensorProductConv):
 
 
 class TensorProductConvScatterSum(ConvolutionBase):
-    def __init__(self, config, idx_dtype=np.int64, torch_op=True):
+    def __init__(self, config, *, torch_op=True):
         assert torch_op
         global torch
         import torch
 
-        super().__init__(config, idx_dtype, torch_op=torch_op, deterministic=False)
+        super().__init__(config, torch_op=torch_op, deterministic=False)
 
         self.reference_tp = TensorProduct(config, torch_op=torch_op)
         from openequivariance.implementations.convolution.scatter import scatter_sum

--- a/openequivariance/implementations/convolution/TensorProductConv.py
+++ b/openequivariance/implementations/convolution/TensorProductConv.py
@@ -32,7 +32,7 @@ class TensorProductConv(torch.nn.Module, LoopUnrollConv):
            fixup-based algorithm. `Default`: ``False``.
     :param kahan: If ``True``, uses Kahan summation to improve accuracy during aggregation. To use this option,
            the input tensors must be in float32 precision AND you must set ``deterministic=True``. *Default*: ``False``.
-    :param use_opaque: If ``True, uses an opaque forward pass that cannot be symbolically traced. *Default*: ``False``.
+    :param use_opaque: If ``True``, uses an opaque forward pass that cannot be symbolically traced. *Default*: ``False``.
     """
 
     def __init__(


### PR DESCRIPTION
This is a design change that makes config (TPProblem) the only positional argument in convolutions. This is because different convolution subclasses have different kwargs and allowing them to be positional, which creates unexpected errors when trying to switch between implementations. 

An open design question is should all the classes accept unexpected kwargs without errors. They could warn on unexpected kwargs. Right now they do not handle them. 

Looking for feedback on the above. 

Additionally there is a bug fix where for the serialization of flops_per_tp and data_per_tp where they need to be ints instead of numpy values. 