### PR TITLE
Adding "_getter" functions in python for TorchBind warnings

### DIFF
--- a/openequivariance/extension/libtorch_tp_jit.cpp
+++ b/openequivariance/extension/libtorch_tp_jit.cpp
@@ -134,7 +134,7 @@ public:
     Map_t fwd_dict, bwd_dict, dbl_bwd_dict, kernel_dims;
     JITTPImpl<JITKernel> internal;
     KernelProp kernelProp;
-    int64_t L3_dim; 
+    int64_t L3_dim, irrep_dtype; 
 
     TorchJITProduct(string kernel_plaintext, Map_t fwd_dict_i, Map_t bwd_dict_i, Map_t dbl_bwd_dict_i, Map_t kernel_dims_i) :
         fwd_dict(fwd_dict_i.copy()),
@@ -148,7 +148,8 @@ public:
                 to_map(kernel_dims_i)
             ),
         kernelProp(kernel_dims, false),
-        L3_dim(kernelProp.L3_dim) 
+        L3_dim(kernelProp.L3_dim),
+        irrep_dtype(kernel_dims_i.at("irrep_dtype")) 
         { }
 
     tuple<  tuple<string, string>, 
@@ -647,6 +648,7 @@ TORCH_LIBRARY_FRAGMENT(libtorch_tp_jit, m) {
             return 0;
         })
         .def_readonly("L3_dim", &TorchJITProduct::L3_dim)
+        .def_readonly("irrep_dtype", &TorchJITProduct::irrep_dtype)
         .def("__eq__", [](const c10::IValue & self, const c10::IValue& other) -> bool {
             return self.is(other); 
         })

--- a/openequivariance/implementations/LoopUnrollTP.py
+++ b/openequivariance/implementations/LoopUnrollTP.py
@@ -183,8 +183,11 @@ class LoopUnrollTP(TensorProductBase):
             def backward_rawptr(*args, **kwargs):
                 pass
 
-            def get_L3_dim(self):
+            def L3_dim_getter(self):
                 return self.kernel_dims["L3_dim"]
+
+            def irrep_dtype_getter(self):
+                return self.kernel_dims["irrep_dtype"]
 
         @torch.library.register_fake("libtorch_tp_jit::jit_tp_forward")
         def fake_forward(jit, L1_in, L2_in, W):

--- a/openequivariance/implementations/convolution/LoopUnrollConv.py
+++ b/openequivariance/implementations/convolution/LoopUnrollConv.py
@@ -296,6 +296,12 @@ class LoopUnrollConv(ConvolutionBase):
             def double_backward_rawptrs(*args, **kwargs):
                 pass
 
+            def L3_dim_getter(self):
+                return self.kernel_dims["L3_dim"]
+
+            def irrep_dtype_getter(self):
+                return self.kernel_dims["irrep_dtype"]
+
         @torch.library.register_fake("libtorch_tp_jit::jit_conv_forward")
         def fake_forward(
             jit, L1_in, L2_in, W, rows, cols, workspace_buffer, sender_perm


### PR DESCRIPTION
The addition of the "_getter" functions is to match a naming convention that TorchBind expects. This quiets warnings that appeared in the NequIP test. I add irrep_dtype to TP even thought we don't immediately use it just to have it available and similar to the TPConv to maintain a similar interface.  