### PR TITLE
Multi device bugfix

### DIFF
--- a/openequivariance/CMakeLists.txt
+++ b/openequivariance/CMakeLists.txt
@@ -117,7 +117,7 @@ endfunction()
 
 find_package(CUDAToolkit QUIET)
 find_package(hip QUIET)
-find_package(rocblas QUIET)
+find_package(hipblas QUIET)
 
 if(CUDAToolkit_FOUND)
     message(STATUS "Building stable extension with CUDA backend.")
@@ -159,10 +159,10 @@ if(hip_FOUND)
         CXX_STANDARD 17
     )
 
-    if(TARGET roc::rocblas)
-        set(HIP_BLAS_LIB roc::rocblas)
+    if(TARGET roc::hipblas)
+        set(HIP_BLAS_LIB roc::hipblas)
     else()
-        set(HIP_BLAS_LIB rocblas)
+        set(HIP_BLAS_LIB hipblas)
     endif()
 
     set(HIP_LINK_LIBS

--- a/openequivariance/openequivariance/_torch/TensorProductConv.py
+++ b/openequivariance/openequivariance/_torch/TensorProductConv.py
@@ -87,7 +87,11 @@ class TensorProductConv(torch.nn.Module, LoopUnrollConv, NumpyDoubleBackwardMixi
 
         self.allocate_workspace(self.workspace_size)
 
-        self.dummy_transpose_perm = torch.zeros(1, dtype=torch.int64, device="cuda")
+        self.register_buffer(
+            "dummy_transpose_perm",
+            torch.zeros(1, dtype=torch.int64, device=self.workspace_buffer.device),
+            persistent=False,
+        )
         self.weight_numel = self.config.weight_numel
         self.kernel = string_to_tensor(self.kernel_string)
         self.L3_dim = self.kernel_prop["L3_dim"]
@@ -129,7 +133,9 @@ class TensorProductConv(torch.nn.Module, LoopUnrollConv, NumpyDoubleBackwardMixi
             self.to(result.dtype)
             self._applying = False
 
-        return super()._apply(fn, recurse)
+        out = super()._apply(fn, recurse)
+        self.workspace_ptr = self.workspace_buffer.data_ptr()
+        return out
 
     def __getstate__(self):
         return self.input_args
@@ -184,10 +190,15 @@ class TensorProductConv(torch.nn.Module, LoopUnrollConv, NumpyDoubleBackwardMixi
             sender_perm,
         )
 
-    def allocate_workspace(self, size_bytes):
+    def allocate_workspace(self, size_bytes, device=None):
         self.workspace_size = size_bytes
-        self.workspace_buffer = torch.zeros(
-            size_bytes, dtype=torch.uint8, device="cuda"
+        if device is None:
+            device = getattr(self, "workspace_buffer", None)
+            device = device.device if device is not None else "cuda"
+        self.register_buffer(
+            "workspace_buffer",
+            torch.zeros(size_bytes, dtype=torch.uint8, device=device),
+            persistent=False,
         )
         self.workspace_ptr = self.workspace_buffer.data_ptr()
         logger.info(f"Convolution requires {size_bytes // 1000000}MB of workspace.")

--- a/openequivariance/openequivariance/extension/group_mm.hpp
+++ b/openequivariance/openequivariance/extension/group_mm.hpp
@@ -18,11 +18,6 @@
     using BlasHandleT = hipblasHandle_t;
 #endif
 
-// Returns a BLAS handle ready to launch on (device_index, stream). Defined
-// per-build (libtorch_tp_jit.cpp / libtorch_tp_jit_stable.cpp): both return
-// PyTorch's pooled handle (cuBLAS on CUDA, hipBLAS on ROCm), which arrives
-// with the stream, workspace, and math mode already set for the current
-// device and stream. The caller must hold a device guard for device_index.
 BlasHandleT get_op_blas_handle(int32_t device_index, BlasStream stream);
 
 template<typename T>

--- a/openequivariance/openequivariance/extension/group_mm.hpp
+++ b/openequivariance/openequivariance/extension/group_mm.hpp
@@ -8,24 +8,21 @@
     #include "cublas_v2.h"
     #include <cuda_runtime.h>
 
-    using BlasStream = cudaStream_t;
     using BlasHandleT = cublasHandle_t;
 #elif defined(HIP_BACKEND)
     #include <hipblas/hipblas.h>
     #include <hip/hip_runtime.h>
 
-    using BlasStream = hipStream_t;
     using BlasHandleT = hipblasHandle_t;
 #endif
 
-BlasHandleT get_op_blas_handle(int32_t device_index, BlasStream stream);
+BlasHandleT get_op_blas_handle();
 
 template<typename T>
 void group_gemm_blas(void* A_raw, void* B_raw, void* C_raw,
-        int64_t* ragged_counts, int num_W, int batch_size, int m, int k, int ragged_inner,
-        int32_t device_index, BlasStream stream) {
+        int64_t* ragged_counts, int num_W, int batch_size, int m, int k, int ragged_inner) {
 
-    BlasHandleT handle = get_op_blas_handle(device_index, stream);
+    BlasHandleT handle = get_op_blas_handle();
     T alpha = 1.0, beta = 0.0;
     T* A_base = reinterpret_cast<T*>(A_raw);
     T* B_base = reinterpret_cast<T*>(B_raw);

--- a/openequivariance/openequivariance/extension/group_mm.hpp
+++ b/openequivariance/openequivariance/extension/group_mm.hpp
@@ -8,38 +8,29 @@
     #include "cublas_v2.h"
     #include <cuda_runtime.h>
 
-    struct BlasHandle {
-        cublasHandle_t handle;
-        BlasHandle() {
-            if (cublasCreate(&handle) != CUBLAS_STATUS_SUCCESS)
-                throw std::logic_error("CUBLAS initialization failed");
-        }
-        ~BlasHandle() { cublasDestroy(handle); }
-    };
+    using BlasStream = cudaStream_t;
+    using BlasHandleT = cublasHandle_t;
 #elif defined(HIP_BACKEND)
-    #include "rocblas/rocblas.h"
+    #include <hipblas/hipblas.h>
     #include <hip/hip_runtime.h>
 
-    struct BlasHandle {
-        rocblas_handle handle;
-        BlasHandle() {
-            if (rocblas_create_handle(&handle) != rocblas_status_success)
-                throw std::logic_error("rocBLAS initialization failed");
-        }
-        ~BlasHandle() { rocblas_destroy_handle(handle); }
-    };
+    using BlasStream = hipStream_t;
+    using BlasHandleT = hipblasHandle_t;
 #endif
 
-inline BlasHandle& get_blas_handle() {
-    static BlasHandle handle;
-    return handle;
-}
+// Returns a BLAS handle ready to launch on (device_index, stream). Defined
+// per-build (libtorch_tp_jit.cpp / libtorch_tp_jit_stable.cpp): both return
+// PyTorch's pooled handle (cuBLAS on CUDA, hipBLAS on ROCm), which arrives
+// with the stream, workspace, and math mode already set for the current
+// device and stream. The caller must hold a device guard for device_index.
+BlasHandleT get_op_blas_handle(int32_t device_index, BlasStream stream);
 
 template<typename T>
 void group_gemm_blas(void* A_raw, void* B_raw, void* C_raw,
-        int64_t* ragged_counts, int num_W, int batch_size, int m, int k, int ragged_inner) {
+        int64_t* ragged_counts, int num_W, int batch_size, int m, int k, int ragged_inner,
+        int32_t device_index, BlasStream stream) {
 
-    auto& blas = get_blas_handle();
+    BlasHandleT handle = get_op_blas_handle(device_index, stream);
     T alpha = 1.0, beta = 0.0;
     T* A_base = reinterpret_cast<T*>(A_raw);
     T* B_base = reinterpret_cast<T*>(B_raw);
@@ -52,7 +43,7 @@ void group_gemm_blas(void* A_raw, void* B_raw, void* C_raw,
 #ifdef CUDA_BACKEND
         cublasOperation_t transa, transb;
 #elif defined(HIP_BACKEND)
-        rocblas_operation transa, transb;
+        hipblasOperation_t transa, transb;
 #endif
 
         if (ragged_inner == 0) {
@@ -66,7 +57,7 @@ void group_gemm_blas(void* A_raw, void* B_raw, void* C_raw,
 #ifdef CUDA_BACKEND
             transa = CUBLAS_OP_T; transb = CUBLAS_OP_N;
 #elif defined(HIP_BACKEND)
-            transa = rocblas_operation_transpose; transb = rocblas_operation_none;
+            transa = HIPBLAS_OP_T; transb = HIPBLAS_OP_N;
 #endif
         } else {
             M = k; K = static_cast<int>(ragged_counts[i]); N = m;
@@ -79,7 +70,7 @@ void group_gemm_blas(void* A_raw, void* B_raw, void* C_raw,
 #ifdef CUDA_BACKEND
             transa = CUBLAS_OP_N; transb = CUBLAS_OP_T;
 #elif defined(HIP_BACKEND)
-            transa = rocblas_operation_none; transb = rocblas_operation_transpose;
+            transa = HIPBLAS_OP_N; transb = HIPBLAS_OP_T;
 #endif
         }
         ragged_offset += ragged_counts[i];
@@ -88,7 +79,7 @@ void group_gemm_blas(void* A_raw, void* B_raw, void* C_raw,
 #ifdef CUDA_BACKEND
             cublasStatus_t stat;
             if (std::is_same<T, float>::value) {
-                stat = cublasSgemmStridedBatched(blas.handle,
+                stat = cublasSgemmStridedBatched(handle,
                     transa, transb, M, N, K,
                     reinterpret_cast<float*>(&alpha),
                     reinterpret_cast<float*>(A), lda, strideA,
@@ -97,7 +88,7 @@ void group_gemm_blas(void* A_raw, void* B_raw, void* C_raw,
                     reinterpret_cast<float*>(C), ldc, strideC,
                     batch_size);
             } else if (std::is_same<T, double>::value) {
-                stat = cublasDgemmStridedBatched(blas.handle,
+                stat = cublasDgemmStridedBatched(handle,
                     transa, transb, M, N, K,
                     reinterpret_cast<double*>(&alpha),
                     reinterpret_cast<double*>(A), lda, strideA,
@@ -111,9 +102,9 @@ void group_gemm_blas(void* A_raw, void* B_raw, void* C_raw,
             if (stat != CUBLAS_STATUS_SUCCESS)
                 throw std::logic_error("Grouped GEMM failed!");
 #elif defined(HIP_BACKEND)
-            rocblas_status stat;
+            hipblasStatus_t stat;
             if (std::is_same<T, float>::value) {
-                stat = rocblas_sgemm_strided_batched(blas.handle,
+                stat = hipblasSgemmStridedBatched(handle,
                     transa, transb, M, N, K,
                     reinterpret_cast<float*>(&alpha),
                     reinterpret_cast<float*>(A), lda, strideA,
@@ -122,7 +113,7 @@ void group_gemm_blas(void* A_raw, void* B_raw, void* C_raw,
                     reinterpret_cast<float*>(C), ldc, strideC,
                     batch_size);
             } else if (std::is_same<T, double>::value) {
-                stat = rocblas_dgemm_strided_batched(blas.handle,
+                stat = hipblasDgemmStridedBatched(handle,
                     transa, transb, M, N, K,
                     reinterpret_cast<double*>(&alpha),
                     reinterpret_cast<double*>(A), lda, strideA,
@@ -133,7 +124,7 @@ void group_gemm_blas(void* A_raw, void* B_raw, void* C_raw,
             } else {
                 throw std::logic_error("Unsupported datatype for grouped GEMM!");
             }
-            if (stat != rocblas_status_success)
+            if (stat != HIPBLAS_STATUS_SUCCESS)
                 throw std::logic_error("Grouped GEMM failed!");
 #endif
         }

--- a/openequivariance/openequivariance/extension/libtorch_tp_jit.cpp
+++ b/openequivariance/openequivariance/extension/libtorch_tp_jit.cpp
@@ -93,9 +93,7 @@ Stream get_current_stream(int32_t device_index) {
 #endif
 }
 
-BlasHandleT get_op_blas_handle(int32_t device_index, BlasStream stream) {
-    (void)device_index;
-    (void)stream;
+BlasHandleT get_op_blas_handle() {
     return at::cuda::getCurrentCUDABlasHandle();
 }
 

--- a/openequivariance/openequivariance/extension/libtorch_tp_jit.cpp
+++ b/openequivariance/openequivariance/extension/libtorch_tp_jit.cpp
@@ -94,11 +94,6 @@ Stream get_current_stream(int32_t device_index) {
 }
 
 BlasHandleT get_op_blas_handle(int32_t device_index, BlasStream stream) {
-    // The caller's device guard makes device_index current, and `stream` is
-    // that device's current stream, so PyTorch's handle arrives configured
-    // for exactly this (device, stream) with its workspace and math mode
-    // managed by PyTorch. On ROCm the same-named function returns a
-    // hipblasHandle_t.
     (void)device_index;
     (void)stream;
     return at::cuda::getCurrentCUDABlasHandle();

--- a/openequivariance/openequivariance/extension/libtorch_tp_jit.cpp
+++ b/openequivariance/openequivariance/extension/libtorch_tp_jit.cpp
@@ -3,10 +3,13 @@
 
 #ifdef CUDA_BACKEND
     #include <ATen/cuda/CUDAContext.h>
+    #include <c10/cuda/CUDAGuard.h>
 #endif
 
 #ifdef HIP_BACKEND
+    #include <ATen/hip/HIPContext.h>
     #include <c10/hip/HIPStream.h>
+    #include <c10/hip/HIPGuard.h>
 #endif
 
 #include <ATen/Operators.h>
@@ -28,6 +31,13 @@ constexpr Dtype kByte = torch::kByte;
 #define BOX(x) x
 #define REGISTER_LIBRARY_IMPL TORCH_LIBRARY_IMPL
 #define REGISTER_LIBRARY TORCH_LIBRARY
+
+#ifdef CUDA_BACKEND
+    using DeviceGuard = c10::cuda::CUDAGuard;
+#endif
+#ifdef HIP_BACKEND
+    using DeviceGuard = c10::hip::HIPGuard;
+#endif
 
 #include "torch_core.hpp"
 
@@ -74,13 +84,24 @@ void *data_ptr(const Tensor &tensor) {
         throw std::logic_error("Unsupported tensor datatype!");
 }
 
-Stream get_current_stream() {
+Stream get_current_stream(int32_t device_index) {
 #ifdef CUDA_BACKEND
-    return c10::cuda::getCurrentCUDAStream();
+    return c10::cuda::getCurrentCUDAStream(device_index);
 #endif
 #ifdef HIP_BACKEND
-    return c10::hip::getCurrentHIPStream();
+    return c10::hip::getCurrentHIPStream(device_index);
 #endif
+}
+
+BlasHandleT get_op_blas_handle(int32_t device_index, BlasStream stream) {
+    // The caller's device guard makes device_index current, and `stream` is
+    // that device's current stream, so PyTorch's handle arrives configured
+    // for exactly this (device, stream) with its workspace and math mode
+    // managed by PyTorch. On ROCm the same-named function returns a
+    // hipblasHandle_t.
+    (void)device_index;
+    (void)stream;
+    return at::cuda::getCurrentCUDABlasHandle();
 }
 
 namespace py=pybind11;

--- a/openequivariance/openequivariance/extension/libtorch_tp_jit_stable.cpp
+++ b/openequivariance/openequivariance/extension/libtorch_tp_jit_stable.cpp
@@ -75,9 +75,7 @@ Stream get_current_stream(int32_t device_index) {
     return static_cast<Stream>(stream_ptr);
 }
 
-BlasHandleT get_op_blas_handle(int32_t device_index, BlasStream stream) {
-    (void)device_index;
-    (void)stream;
+BlasHandleT get_op_blas_handle() {
     void* handle = nullptr;
     TORCH_ERROR_CODE_CHECK(torch_get_current_cuda_blas_handle(&handle));
     return static_cast<BlasHandleT>(handle);

--- a/openequivariance/openequivariance/extension/libtorch_tp_jit_stable.cpp
+++ b/openequivariance/openequivariance/extension/libtorch_tp_jit_stable.cpp
@@ -76,11 +76,6 @@ Stream get_current_stream(int32_t device_index) {
 }
 
 BlasHandleT get_op_blas_handle(int32_t device_index, BlasStream stream) {
-    // The caller's device guard makes device_index current, and `stream` is
-    // that device's current stream, so PyTorch's handle arrives configured
-    // for exactly this (device, stream) with its workspace and math mode
-    // managed by PyTorch. On ROCm builds of libtorch this shim symbol keeps
-    // its name and returns a hipblasHandle_t.
     (void)device_index;
     (void)stream;
     void* handle = nullptr;

--- a/openequivariance/openequivariance/extension/libtorch_tp_jit_stable.cpp
+++ b/openequivariance/openequivariance/extension/libtorch_tp_jit_stable.cpp
@@ -11,6 +11,7 @@
 #include <torch/headeronly/util/Exception.h>
 #include <torch/headeronly/util/shim_utils.h>
 #include <torch/csrc/inductor/aoti_torch/c/shim.h>
+#include <torch/csrc/stable/c/shim.h>
 
 
 using Tensor = torch::stable::Tensor;
@@ -26,6 +27,8 @@ constexpr Dtype kByte = torch::headeronly::ScalarType::Byte;
 #define BOX(x) TORCH_BOX(x)
 #define REGISTER_LIBRARY_IMPL STABLE_TORCH_LIBRARY_IMPL
 #define REGISTER_LIBRARY STABLE_TORCH_LIBRARY
+
+using DeviceGuard = torch::stable::accelerator::DeviceGuard;
 
 #include "torch_core.hpp"
 
@@ -66,16 +69,23 @@ void *data_ptr(const Tensor &tensor) {
     return tensor.data_ptr();
 }
 
-Stream get_current_stream() {
-    auto device_idx = torch::stable::accelerator::getCurrentDeviceIndex();
+Stream get_current_stream(int32_t device_index) {
     void* stream_ptr = nullptr;
-    TORCH_ERROR_CODE_CHECK(aoti_torch_get_current_cuda_stream(device_idx, &stream_ptr));
+    TORCH_ERROR_CODE_CHECK(aoti_torch_get_current_cuda_stream(device_index, &stream_ptr));
+    return static_cast<Stream>(stream_ptr);
+}
 
-    #ifdef CUDA_BACKEND
-        return static_cast<Stream>(stream_ptr); 
-    #elif defined(HIP_BACKEND)
-        return static_cast<Stream>(stream_ptr);
-    #endif
+BlasHandleT get_op_blas_handle(int32_t device_index, BlasStream stream) {
+    // The caller's device guard makes device_index current, and `stream` is
+    // that device's current stream, so PyTorch's handle arrives configured
+    // for exactly this (device, stream) with its workspace and math mode
+    // managed by PyTorch. On ROCm builds of libtorch this shim symbol keeps
+    // its name and returns a hipblasHandle_t.
+    (void)device_index;
+    (void)stream;
+    void* handle = nullptr;
+    TORCH_ERROR_CODE_CHECK(torch_get_current_cuda_blas_handle(&handle));
+    return static_cast<BlasHandleT>(handle);
 }
 
 #ifdef CUDA_BACKEND

--- a/openequivariance/openequivariance/extension/stubs/stream.cpp
+++ b/openequivariance/openequivariance/extension/stubs/stream.cpp
@@ -2,16 +2,6 @@
 #include <cstdio>
 #include <torch/csrc/inductor/aoti_torch/c/shim.h>
 
-// The stable extension is linked on a machine with CPU-only libtorch, where
-// no libtorch_cuda/libtorch_hip exists. This file builds a stand-in library
-// with the real one's SONAME so the link succeeds; at runtime the DT_NEEDED
-// entry is satisfied by the real library, already loaded via `import torch`,
-// and this file is never opened. It is not shipped in the wheel.
-//
-// These bodies can therefore only execute in a misconfigured process (e.g.
-// the extension loaded without torch). Fail through the shim's error-code
-// contract - TORCH_ERROR_CODE_CHECK at the call site turns this into a
-// catchable exception - rather than returning success with garbage outputs.
 namespace {
 
 AOTITorchError oeq_stub_called(const char *name) {

--- a/openequivariance/openequivariance/extension/stubs/stream.cpp
+++ b/openequivariance/openequivariance/extension/stubs/stream.cpp
@@ -1,27 +1,51 @@
 #include <cstdint>
+#include <cstdio>
 #include <torch/csrc/inductor/aoti_torch/c/shim.h>
 
-// Link-time stand-ins for symbols that live in the real libtorch_cuda /
-// libtorch_hip, which is already loaded at runtime and wins symbol
-// resolution. These bodies never execute in production.
+// The stable extension is linked on a machine with CPU-only libtorch, where
+// no libtorch_cuda/libtorch_hip exists. This file builds a stand-in library
+// with the real one's SONAME so the link succeeds; at runtime the DT_NEEDED
+// entry is satisfied by the real library, already loaded via `import torch`,
+// and this file is never opened. It is not shipped in the wheel.
+//
+// These bodies can therefore only execute in a misconfigured process (e.g.
+// the extension loaded without torch). Fail through the shim's error-code
+// contract - TORCH_ERROR_CODE_CHECK at the call site turns this into a
+// catchable exception - rather than returning success with garbage outputs.
+namespace {
+
+AOTITorchError oeq_stub_called(const char *name) {
+    fprintf(stderr,
+            "OpenEquivariance: link-time stub '%s' executed; the real "
+            "libtorch_cuda/libtorch_hip is not loaded (import torch before "
+            "loading the OpenEquivariance extension).\n",
+            name);
+    return AOTI_TORCH_FAILURE;
+}
+
+} // namespace
+
 extern "C" {
     AOTITorchError aoti_torch_get_current_cuda_stream(int32_t device_index, void** ret_stream) {
-        return 0;
+        if (ret_stream) *ret_stream = nullptr;
+        return oeq_stub_called("aoti_torch_get_current_cuda_stream");
     }
 
     AOTITorchError aoti_torch_create_device_guard(int32_t device_index, DeviceGuardHandle* ret_guard) {
-        return 0;
+        if (ret_guard) *ret_guard = nullptr;
+        return oeq_stub_called("aoti_torch_create_device_guard");
     }
 
     AOTITorchError aoti_torch_delete_device_guard(DeviceGuardHandle guard) {
-        return 0;
+        return oeq_stub_called("aoti_torch_delete_device_guard");
     }
 
     AOTITorchError aoti_torch_device_guard_set_index(DeviceGuardHandle guard, int32_t device_index) {
-        return 0;
+        return oeq_stub_called("aoti_torch_device_guard_set_index");
     }
 
     AOTITorchError torch_get_current_cuda_blas_handle(void** ret_handle) {
-        return 0;
+        if (ret_handle) *ret_handle = nullptr;
+        return oeq_stub_called("torch_get_current_cuda_blas_handle");
     }
 }

--- a/openequivariance/openequivariance/extension/stubs/stream.cpp
+++ b/openequivariance/openequivariance/extension/stubs/stream.cpp
@@ -1,8 +1,27 @@
 #include <cstdint>
 #include <torch/csrc/inductor/aoti_torch/c/shim.h>
 
+// Link-time stand-ins for symbols that live in the real libtorch_cuda /
+// libtorch_hip, which is already loaded at runtime and wins symbol
+// resolution. These bodies never execute in production.
 extern "C" {
     AOTITorchError aoti_torch_get_current_cuda_stream(int32_t device_index, void** ret_stream) {
+        return 0;
+    }
+
+    AOTITorchError aoti_torch_create_device_guard(int32_t device_index, DeviceGuardHandle* ret_guard) {
+        return 0;
+    }
+
+    AOTITorchError aoti_torch_delete_device_guard(DeviceGuardHandle guard) {
+        return 0;
+    }
+
+    AOTITorchError aoti_torch_device_guard_set_index(DeviceGuardHandle guard, int32_t device_index) {
+        return 0;
+    }
+
+    AOTITorchError torch_get_current_cuda_blas_handle(void** ret_handle) {
         return 0;
     }
 }

--- a/openequivariance/openequivariance/extension/torch_core.hpp
+++ b/openequivariance/openequivariance/extension/torch_core.hpp
@@ -128,6 +128,21 @@ inline void check_tensor(const Tensor &tensor,
           ". Got: ", static_cast<int>(tensor.scalar_type()));
 }
 
+inline void check_same_device(
+        std::initializer_list<std::pair<const Tensor*, const char*>> tensors) {
+    auto it = tensors.begin();
+    const Tensor *first = it->first;
+    const char *first_name = it->second;
+    for (++it; it != tensors.end(); ++it) {
+        TCHECK(it->first->get_device() == first->get_device(),
+              "Tensor '", it->second, "' is on device ",
+              static_cast<int>(it->first->get_device()),
+              ", but tensor '", first_name, "' is on device ",
+              static_cast<int>(first->get_device()),
+              ". All tensors must be on the same device.");
+    }
+}
+
 inline std::unordered_map<std::string, int64_t> parse_json_config(const json &j_obj) {
     std::unordered_map<std::string, int64_t> result;
     for (const auto &kv : j_obj.object_items()) {
@@ -286,6 +301,8 @@ inline Tensor jit_tp_forward(
     else
         check_tensor(W, {num_batch, k.weight_numel}, k.weight_dtype, "W");
 
+    check_same_device({{&L1_in, "L1_in"}, {&L2_in, "L2_in"}, {&W, "W"}});
+
     Tensor L3_out = tensor_empty_like(L1_in, make_sizes({num_batch, k.L3_dim}));
 
     Tensor L1_contig = tensor_contiguous(L1_in);
@@ -324,6 +341,9 @@ inline tuple<Tensor, Tensor, Tensor> jit_tp_backward(
         check_tensor(W, {k.weight_numel}, k.weight_dtype, "W");
     else
         check_tensor(W, {num_batch, k.weight_numel}, k.weight_dtype, "W");
+
+    check_same_device({{&L1_in, "L1_in"}, {&L2_in, "L2_in"}, {&W, "W"},
+                       {&L3_grad, "L3_grad"}});
 
     Tensor L1_grad = tensor_empty_like(L1_in, tensor_sizes_vec(L1_in));
     Tensor L2_grad = tensor_empty_like(L2_in, tensor_sizes_vec(L2_in));
@@ -377,6 +397,10 @@ inline tuple<Tensor, Tensor, Tensor, Tensor> jit_tp_double_backward(
         check_tensor(W, {num_batch, k.weight_numel}, k.weight_dtype, "W");
         check_tensor(W_dgrad, {num_batch, k.weight_numel}, k.weight_dtype, "W_dgrad");
     }
+
+    check_same_device({{&L1_in, "L1_in"}, {&L2_in, "L2_in"}, {&W, "W"},
+                       {&L3_grad, "L3_grad"}, {&L1_dgrad, "L1_dgrad"},
+                       {&L2_dgrad, "L2_dgrad"}, {&W_dgrad, "W_dgrad"}});
 
     Tensor L1_grad = tensor_empty_like(L1_in, tensor_sizes_vec(L1_in));
     Tensor L2_grad = tensor_empty_like(L2_in, tensor_sizes_vec(L2_in));
@@ -447,6 +471,11 @@ inline Tensor jit_conv_forward(
     else
         check_tensor(W, {nnz, k.weight_numel}, k.weight_dtype, "W");
 
+    check_same_device({{&L1_in, "L1_in"}, {&L2_in, "L2_in"}, {&W, "W"},
+                       {&rows, "rows"}, {&cols, "cols"}, {&workspace, "workspace"}});
+    if (k.deterministic)
+        check_same_device({{&L1_in, "L1_in"}, {&transpose_perm, "transpose_perm"}});
+
     Tensor L3_out = tensor_zeros_like(L1_in, make_sizes({node_count, k.L3_dim}));
 
     Tensor L1_contig = tensor_contiguous(L1_in);
@@ -504,6 +533,12 @@ inline tuple<Tensor, Tensor, Tensor> jit_conv_backward(
         check_tensor(W, {k.weight_numel}, k.weight_dtype, "W");
     else
         check_tensor(W, {nnz, k.weight_numel}, k.weight_dtype, "W");
+
+    check_same_device({{&L1_in, "L1_in"}, {&L2_in, "L2_in"}, {&W, "W"},
+                       {&L3_grad, "L3_grad"}, {&rows, "rows"}, {&cols, "cols"},
+                       {&workspace, "workspace"}});
+    if (k.deterministic)
+        check_same_device({{&L1_in, "L1_in"}, {&transpose_perm, "transpose_perm"}});
 
     Tensor L1_grad = tensor_zeros_like(L1_in, tensor_sizes_vec(L1_in));
     Tensor L2_grad = tensor_zeros_like(L2_in, tensor_sizes_vec(L2_in));
@@ -579,6 +614,13 @@ inline tuple<Tensor, Tensor, Tensor, Tensor> jit_conv_double_backward(
         check_tensor(W_dgrad, {nnz, k.weight_numel}, k.weight_dtype, "W_dgrad");
     }
 
+    check_same_device({{&L1_in, "L1_in"}, {&L2_in, "L2_in"}, {&W, "W"},
+                       {&L3_grad, "L3_grad"}, {&L1_dgrad, "L1_dgrad"},
+                       {&L2_dgrad, "L2_dgrad"}, {&W_dgrad, "W_dgrad"},
+                       {&rows, "rows"}, {&cols, "cols"}, {&workspace, "workspace"}});
+    if (k.deterministic)
+        check_same_device({{&L1_in, "L1_in"}, {&transpose_perm, "transpose_perm"}});
+
     Tensor L1_grad = tensor_zeros_like(L1_in, tensor_sizes_vec(L1_in));
     Tensor L2_grad = tensor_zeros_like(L2_in, tensor_sizes_vec(L2_in));
     Tensor W_grad = tensor_empty_like(W, tensor_sizes_vec(W));
@@ -623,6 +665,11 @@ inline Tensor group_gemm(
         int64_t num_W, int64_t batch_size, int64_t m, int64_t k, int64_t ragged_inner) {
     TCHECK(A.scalar_type() == B.scalar_type(), "group_gemm: A and B must have the same dtype");
     TCHECK(ragged_counts.scalar_type() == kLong, "group_gemm: ragged_counts must be int64");
+    TCHECK(A.is_cuda(), "group_gemm: A must be a GPU tensor");
+    TCHECK(B.is_cuda(), "group_gemm: B must be a GPU tensor");
+    check_same_device({{&A, "A"}, {&B, "B"}});
+    TCHECK(ragged_counts.is_cpu(),
+          "group_gemm: ragged_counts must be a CPU tensor; its values are read on the host");
 
     Tensor A_c    = tensor_contiguous(A);
     Tensor B_c    = tensor_contiguous(B);

--- a/openequivariance/openequivariance/extension/torch_core.hpp
+++ b/openequivariance/openequivariance/extension/torch_core.hpp
@@ -692,7 +692,6 @@ inline Tensor group_gemm(
 
     const int32_t device_index = static_cast<int32_t>(A.get_device());
     DeviceGuard device_guard(device_index);
-    Stream stream = get_current_stream(device_index);
 
     Tensor A_c    = tensor_contiguous(A);
     Tensor B_c    = tensor_contiguous(B);
@@ -709,12 +708,10 @@ inline Tensor group_gemm(
 
     if (A.scalar_type() == kFloat) {
         group_gemm_blas<float>(data_ptr(A_c), data_ptr(B_c), data_ptr(C), rc_ptr,
-            (int)num_W, (int)batch_size, (int)m, (int)k, (int)ragged_inner,
-            device_index, stream);
+            (int)num_W, (int)batch_size, (int)m, (int)k, (int)ragged_inner);
     } else if (A.scalar_type() == kDouble) {
         group_gemm_blas<double>(data_ptr(A_c), data_ptr(B_c), data_ptr(C), rc_ptr,
-            (int)num_W, (int)batch_size, (int)m, (int)k, (int)ragged_inner,
-            device_index, stream);
+            (int)num_W, (int)batch_size, (int)m, (int)k, (int)ragged_inner);
     } else {
         throw std::logic_error("group_gemm: unsupported dtype, expected float32 or float64");
     }

--- a/openequivariance/openequivariance/extension/torch_core.hpp
+++ b/openequivariance/openequivariance/extension/torch_core.hpp
@@ -42,7 +42,11 @@ Tensor tensor_zeros_like(const Tensor &ref, const std::vector<int64_t> &sizes);
 void tensor_zero_(Tensor &tensor);
 
 void alert_not_deterministic(const char *name);
-Stream get_current_stream();
+
+// Current PyTorch stream for the given device, NOT the thread's current
+// device. Each op must guard to its input tensor's device (DeviceGuard,
+// aliased per-backend) before launching work, then take that device's stream.
+Stream get_current_stream(int32_t device_index);
 
 const uint8_t *tensor_data_ptr_u8(const Tensor &tensor);
 void *data_ptr(const Tensor &tensor);
@@ -289,7 +293,10 @@ inline Tensor jit_tp_forward(
         int64_t L3_dim) {
 
     auto [jit_kernel, k] = compile_tp_with_caching(json_bytes, hash);
-    Stream stream = get_current_stream();
+
+    const int32_t device_index = static_cast<int32_t>(L1_in.get_device());
+    DeviceGuard device_guard(device_index);
+    Stream stream = get_current_stream(device_index);
 
     const int64_t num_batch = L1_in.size(0);
 
@@ -329,7 +336,10 @@ inline tuple<Tensor, Tensor, Tensor> jit_tp_backward(
         Tensor L3_grad) {
 
     auto [jit_kernel, k] = compile_tp_with_caching(json_bytes, hash);
-    Stream stream = get_current_stream();
+
+    const int32_t device_index = static_cast<int32_t>(L1_in.get_device());
+    DeviceGuard device_guard(device_index);
+    Stream stream = get_current_stream(device_index);
 
     const int64_t num_batch = L1_in.size(0);
 
@@ -380,7 +390,10 @@ inline tuple<Tensor, Tensor, Tensor, Tensor> jit_tp_double_backward(
         Tensor W_dgrad) {
 
     auto [jit_kernel, k] = compile_tp_with_caching(json_bytes, hash);
-    Stream stream = get_current_stream();
+
+    const int32_t device_index = static_cast<int32_t>(L1_in.get_device());
+    DeviceGuard device_guard(device_index);
+    Stream stream = get_current_stream(device_index);
 
     const int64_t num_batch = L1_in.size(0);
 
@@ -450,7 +463,10 @@ inline Tensor jit_conv_forward(
         Tensor transpose_perm) {
 
     auto [jit_kernel, k] = compile_conv_with_caching(json_bytes, hash);
-    Stream stream = get_current_stream();
+
+    const int32_t device_index = static_cast<int32_t>(L1_in.get_device());
+    DeviceGuard device_guard(device_index);
+    Stream stream = get_current_stream(device_index);
 
     const int64_t nnz = rows.size(0);
     const int64_t node_count = L1_in.size(0);
@@ -511,7 +527,10 @@ inline tuple<Tensor, Tensor, Tensor> jit_conv_backward(
         Tensor transpose_perm) {
 
     auto [jit_kernel, k] = compile_conv_with_caching(json_bytes, hash);
-    Stream stream = get_current_stream();
+
+    const int32_t device_index = static_cast<int32_t>(L1_in.get_device());
+    DeviceGuard device_guard(device_index);
+    Stream stream = get_current_stream(device_index);
 
     const int64_t nnz = rows.size(0);
     const int64_t node_count = L1_in.size(0);
@@ -586,7 +605,10 @@ inline tuple<Tensor, Tensor, Tensor, Tensor> jit_conv_double_backward(
         Tensor transpose_perm) {
 
     auto [jit_kernel, k] = compile_conv_with_caching(json_bytes, hash);
-    Stream stream = get_current_stream();
+
+    const int32_t device_index = static_cast<int32_t>(L1_in.get_device());
+    DeviceGuard device_guard(device_index);
+    Stream stream = get_current_stream(device_index);
 
     const int64_t nnz = rows.size(0);
     const int64_t node_count = L1_in.size(0);
@@ -671,6 +693,10 @@ inline Tensor group_gemm(
     TCHECK(ragged_counts.is_cpu(),
           "group_gemm: ragged_counts must be a CPU tensor; its values are read on the host");
 
+    const int32_t device_index = static_cast<int32_t>(A.get_device());
+    DeviceGuard device_guard(device_index);
+    Stream stream = get_current_stream(device_index);
+
     Tensor A_c    = tensor_contiguous(A);
     Tensor B_c    = tensor_contiguous(B);
     Tensor rc_c   = tensor_contiguous(ragged_counts);
@@ -686,10 +712,12 @@ inline Tensor group_gemm(
 
     if (A.scalar_type() == kFloat) {
         group_gemm_blas<float>(data_ptr(A_c), data_ptr(B_c), data_ptr(C), rc_ptr,
-            (int)num_W, (int)batch_size, (int)m, (int)k, (int)ragged_inner);
+            (int)num_W, (int)batch_size, (int)m, (int)k, (int)ragged_inner,
+            device_index, stream);
     } else if (A.scalar_type() == kDouble) {
         group_gemm_blas<double>(data_ptr(A_c), data_ptr(B_c), data_ptr(C), rc_ptr,
-            (int)num_W, (int)batch_size, (int)m, (int)k, (int)ragged_inner);
+            (int)num_W, (int)batch_size, (int)m, (int)k, (int)ragged_inner,
+            device_index, stream);
     } else {
         throw std::logic_error("group_gemm: unsupported dtype, expected float32 or float64");
     }

--- a/openequivariance/openequivariance/extension/torch_core.hpp
+++ b/openequivariance/openequivariance/extension/torch_core.hpp
@@ -43,9 +43,6 @@ void tensor_zero_(Tensor &tensor);
 
 void alert_not_deterministic(const char *name);
 
-// Current PyTorch stream for the given device, NOT the thread's current
-// device. Each op must guard to its input tensor's device (DeviceGuard,
-// aliased per-backend) before launching work, then take that device's stream.
 Stream get_current_stream(int32_t device_index);
 
 const uint8_t *tensor_data_ptr_u8(const Tensor &tensor);

--- a/tests/stream_ordering_test.py
+++ b/tests/stream_ordering_test.py
@@ -82,7 +82,7 @@ def _build_tp(device, gen):
 
 def _build_conv_atomic(device, gen):
     tpp = _tpp()
-    conv = TensorProductConv(tpp, torch_op=True, deterministic=False)
+    conv = TensorProductConv(tpp, torch_op=True, deterministic=False).to(device)
     receivers = torch.tensor([0, 1, 1, 2], device=device, dtype=torch.long)
     senders = torch.tensor([1, 0, 2, 1], device=device, dtype=torch.long)
     X = torch.rand(3, tpp.irreps_in1.dim, device=device, generator=gen)

--- a/tests/stream_ordering_test.py
+++ b/tests/stream_ordering_test.py
@@ -1,0 +1,177 @@
+# ruff: noqa: E731
+"""Stream-ordering and device-mismatch tests for every GPU-launching API:
+the raw group_gemm op, TensorProduct, and TensorProductConv.
+
+Technique: zero one input, stall a stream with torch.cuda._sleep, enqueue the
+real input write behind the stall, then run the op with that stream current.
+An op that enqueues on the correct stream waits for the write; an op that uses
+the wrong stream (e.g. the legacy default stream, or another device's stream)
+always reads stale zeros, so the failure is deterministic rather than a race.
+
+Expected against the current implementation:
+  - test_ordering_current_device: FAILS for group_gemm (cuBLAS work is issued
+    with no stream set, i.e. the legacy default stream); PASSES for tp/conv,
+    which are stream-correct on a single device.
+  - test_cuda_graph_capture: RAISES for group_gemm (legacy-stream work aborts
+    stream capture); PASSES for tp/conv.
+  - test_ordering_nondefault_device (2+ GPUs): FAILS for all three cases, since
+    every op derives device and stream from the host thread, not its inputs.
+    tp/conv may fail as an async CUDA error or process abort rather than a
+    clean assert, because kernel-launch errors currently call exit(1).
+"""
+
+import pytest
+import torch
+
+from e3nn import o3
+
+from openequivariance import TensorProduct, TensorProductConv, TPProblem
+from openequivariance._torch import extlib  # noqa: F401  loads the extension
+
+pytestmark = pytest.mark.skipif(
+    not torch.cuda.is_available(), reason="CUDA device required"
+)
+
+# ~50-100ms spin on modern GPUs: much longer than any launch latency here.
+SLEEP_CYCLES = int(2e8)
+
+NUM_W, NUM_FEATURES, M, K, N_PER_W = 4, 8, 16, 32, 256
+N_BATCH = 1000
+
+
+def _tpp():
+    return TPProblem(
+        o3.Irreps("1x2e"),
+        o3.Irreps("1x3e"),
+        o3.Irreps("1x2e"),
+        [(0, 0, 0, "uvu", True)],
+        shared_weights=False,
+        internal_weights=False,
+    )
+
+
+class Case:
+    """Callable op plus its input tensors; tensors[0] is the delayed input."""
+
+    def __init__(self, fn, tensors):
+        self.fn = fn
+        self.tensors = tensors
+
+    def __call__(self):
+        return self.fn(*self.tensors)
+
+
+def _build_group_gemm(device, gen):
+    counts = torch.full((NUM_W,), N_PER_W, dtype=torch.int64)  # CPU tensor
+    A = torch.randn(NUM_W, NUM_FEATURES, M, K, device=device, generator=gen)
+    B = torch.randn(
+        NUM_W * N_PER_W, NUM_FEATURES, K, device=device, generator=gen
+    )
+    fn = lambda A, B: torch.ops.libtorch_tp_jit.group_gemm(
+        A, B, counts, NUM_W, NUM_FEATURES, M, K, 0
+    )
+    return Case(fn, [A, B])
+
+
+def _build_tp(device, gen):
+    tpp = _tpp()
+    tp = TensorProduct(tpp)
+    X = torch.rand(N_BATCH, tpp.irreps_in1.dim, device=device, generator=gen)
+    Y = torch.rand(N_BATCH, tpp.irreps_in2.dim, device=device, generator=gen)
+    W = torch.rand(N_BATCH, tpp.weight_numel, device=device, generator=gen)
+    return Case(tp, [X, Y, W])
+
+
+def _build_conv_atomic(device, gen):
+    tpp = _tpp()
+    conv = TensorProductConv(tpp, torch_op=True, deterministic=False)
+    receivers = torch.tensor([0, 1, 1, 2], device=device, dtype=torch.long)
+    senders = torch.tensor([1, 0, 2, 1], device=device, dtype=torch.long)
+    X = torch.rand(3, tpp.irreps_in1.dim, device=device, generator=gen)
+    Y = torch.rand(4, tpp.irreps_in2.dim, device=device, generator=gen)
+    W = torch.rand(4, tpp.weight_numel, device=device, generator=gen)
+    return Case(conv, [X, Y, W, receivers, senders])
+
+
+BUILDERS = {
+    "group_gemm": _build_group_gemm,
+    "tp": _build_tp,
+    "conv_atomic": _build_conv_atomic,
+}
+
+
+@pytest.fixture(params=list(BUILDERS))
+def case_name(request):
+    return request.param
+
+
+def _build(case_name, device):
+    gen = torch.Generator(device=device)
+    gen.manual_seed(0)
+    return BUILDERS[case_name](device, gen)
+
+
+def _delayed_run(case, tensor_device, stream):
+    """Re-write the delayed input on a stalled stream, then run the op with
+    that stream current on the tensors' device. The op must wait for the
+    write; reading early yields zeros."""
+    delayed = case.tensors[0]
+    src = delayed.clone()
+    torch.cuda.synchronize(tensor_device)
+    delayed.zero_()
+    torch.cuda.synchronize(tensor_device)
+
+    with torch.cuda.device(tensor_device), torch.cuda.stream(stream):
+        torch.cuda._sleep(SLEEP_CYCLES)
+        delayed.copy_(src)
+
+    # Note: torch.cuda.stream() selects the stream on *its* device without
+    # changing the current device, so in the cross-device test the host
+    # thread's current device stays cuda:0 here.
+    with torch.cuda.stream(stream):
+        out = case()
+    torch.cuda.synchronize(tensor_device)
+    return out
+
+
+def test_ordering_current_device(case_name):
+    case = _build(case_name, "cuda")
+    torch.cuda.synchronize()
+    ref = case()
+    torch.cuda.synchronize()
+
+    out = _delayed_run(case, 0, torch.cuda.Stream())
+    torch.testing.assert_close(out, ref)
+
+
+def test_cuda_graph_capture(case_name):
+    case = _build(case_name, "cuda")
+    warmup = torch.cuda.Stream()
+    with torch.cuda.stream(warmup):
+        for _ in range(3):
+            case()
+    torch.cuda.synchronize()
+
+    g = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(g):
+        out = case()
+    g.replay()
+    torch.cuda.synchronize()
+
+    torch.testing.assert_close(out, case())
+
+
+@pytest.mark.skipif(torch.cuda.device_count() < 2, reason="requires 2+ GPUs")
+def test_ordering_nondefault_device(case_name):
+    """All inputs on cuda:1 while the host thread stays on cuda:0. Ops must
+    derive device and stream from their inputs, not from thread state."""
+    assert torch.cuda.current_device() == 0
+
+    case = _build(case_name, "cuda:1")
+    torch.cuda.synchronize(1)
+    ref = case()  # already the report's mismatch scenario
+    torch.cuda.synchronize(1)
+    assert ref.device == case.tensors[0].device
+
+    out = _delayed_run(case, 1, torch.cuda.Stream(device=1))
+    torch.testing.assert_close(out, ref)

--- a/tests/stream_ordering_test.py
+++ b/tests/stream_ordering_test.py
@@ -146,14 +146,17 @@ def test_ordering_current_device(case_name):
 
 def test_cuda_graph_capture(case_name):
     case = _build(case_name, "cuda")
-    warmup = torch.cuda.Stream()
-    with torch.cuda.stream(warmup):
+    # Warm up on the same stream we capture on: JIT compilation and cuBLAS
+    # workspace allocation for this (handle, stream) pair happen here, outside
+    # the capture region.
+    s = torch.cuda.Stream()
+    with torch.cuda.stream(s):
         for _ in range(3):
             case()
     torch.cuda.synchronize()
 
     g = torch.cuda.CUDAGraph()
-    with torch.cuda.graph(g):
+    with torch.cuda.graph(g, stream=s):
         out = case()
     g.replay()
     torch.cuda.synchronize()

--- a/tests/stream_ordering_test.py
+++ b/tests/stream_ordering_test.py
@@ -64,9 +64,7 @@ class Case:
 def _build_group_gemm(device, gen):
     counts = torch.full((NUM_W,), N_PER_W, dtype=torch.int64)  # CPU tensor
     A = torch.randn(NUM_W, NUM_FEATURES, M, K, device=device, generator=gen)
-    B = torch.randn(
-        NUM_W * N_PER_W, NUM_FEATURES, K, device=device, generator=gen
-    )
+    B = torch.randn(NUM_W * N_PER_W, NUM_FEATURES, K, device=device, generator=gen)
     fn = lambda A, B: torch.ops.libtorch_tp_jit.group_gemm(
         A, B, counts, NUM_W, NUM_FEATURES, M, K, 0
     )

--- a/tests/stream_ordering_test.py
+++ b/tests/stream_ordering_test.py
@@ -1,25 +1,4 @@
 # ruff: noqa: E731
-"""Stream-ordering and device-mismatch tests for every GPU-launching API:
-the raw group_gemm op, TensorProduct, and TensorProductConv.
-
-Technique: zero one input, stall a stream with torch.cuda._sleep, enqueue the
-real input write behind the stall, then run the op with that stream current.
-An op that enqueues on the correct stream waits for the write; an op that uses
-the wrong stream (e.g. the legacy default stream, or another device's stream)
-always reads stale zeros, so the failure is deterministic rather than a race.
-
-Expected against the current implementation:
-  - test_ordering_current_device: FAILS for group_gemm (cuBLAS work is issued
-    with no stream set, i.e. the legacy default stream); PASSES for tp/conv,
-    which are stream-correct on a single device.
-  - test_cuda_graph_capture: RAISES for group_gemm (legacy-stream work aborts
-    stream capture); PASSES for tp/conv.
-  - test_ordering_nondefault_device (2+ GPUs): FAILS for all three cases, since
-    every op derives device and stream from the host thread, not its inputs.
-    tp/conv may fail as an async CUDA error or process abort rather than a
-    clean assert, because kernel-launch errors currently call exit(1).
-"""
-
 import pytest
 import torch
 
@@ -110,9 +89,6 @@ def _build(case_name, device):
 
 
 def _delayed_run(case, tensor_device, stream):
-    """Re-write the delayed input on a stalled stream, then run the op with
-    that stream current on the tensors' device. The op must wait for the
-    write; reading early yields zeros."""
     delayed = case.tensors[0]
     src = delayed.clone()
     torch.cuda.synchronize(tensor_device)
@@ -123,9 +99,6 @@ def _delayed_run(case, tensor_device, stream):
         torch.cuda._sleep(SLEEP_CYCLES)
         delayed.copy_(src)
 
-    # Note: torch.cuda.stream() selects the stream on *its* device without
-    # changing the current device, so in the cross-device test the host
-    # thread's current device stays cuda:0 here.
     with torch.cuda.stream(stream):
         out = case()
     torch.cuda.synchronize(tensor_device)
@@ -144,9 +117,6 @@ def test_ordering_current_device(case_name):
 
 def test_cuda_graph_capture(case_name):
     case = _build(case_name, "cuda")
-    # Warm up on the same stream we capture on: JIT compilation and cuBLAS
-    # workspace allocation for this (handle, stream) pair happen here, outside
-    # the capture region.
     s = torch.cuda.Stream()
     with torch.cuda.stream(s):
         for _ in range(3):
@@ -164,8 +134,6 @@ def test_cuda_graph_capture(case_name):
 
 @pytest.mark.skipif(torch.cuda.device_count() < 2, reason="requires 2+ GPUs")
 def test_ordering_nondefault_device(case_name):
-    """All inputs on cuda:1 while the host thread stays on cuda:0. Ops must
-    derive device and stream from their inputs, not from thread state."""
     assert torch.cuda.current_device() == 0
 
     case = _build(case_name, "cuda:1")


### PR DESCRIPTION
This is a PR to harden multi device behavior.
- It adds testing to make sure all tensors are on the same device 
- it adds usage of "device guards". This is how PyTorch signals to apis which do not explicitly take `device`, which device to use. 
- It also adjust how BLAS handles work. BLAS handles must differ across devices. PyTorch keeps a pool of BLAS handles. This PR switches OEQ to using PyTorch's BLAS handles. Just a note that this current design does not set the BLAS precision mode which means it inherits from pytorch settings. I think that's a reasonable design because people can control precision with the idiomatic pytorch methods. If you think this calculation should never be in TF32, then I can add a manual setting command. 
- It adds stream tests to that should fail before the changes from the PR come in on multi device. And should be fixed later. 