### PR TITLE
docs: full CUDA toolkit (NVRTC dev libs) required to build the extension

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -36,7 +36,7 @@ You need the following to install OpenEquivariance:
 
         c++ --version 
         
-    To build the extension with an alternate compiler, set the 
+    To build the extension with an alternate compiler, set the
     ``CC`` and ``CXX``
     environment variable and retry the import:
 
@@ -46,9 +46,23 @@ You need the following to install OpenEquivariance:
         export CXX=/path/to/your/g++
         python -c "import openequivariance"
 
+    Building the extension also requires a **full CUDA toolkit**, including
+    the NVRTC development libraries (the CMake build links ``CUDA::nvrtc``).
+    A compiler-only toolchain — for example conda's ``cuda-nvcc`` package on
+    its own — fails with::
 
-    These configuration steps are required only ONCE after 
-    installation (or upgrade) with pip. 
+        target_link_libraries ... CUDA::nvrtc but the target was not found
+
+    In that case, point CMake at a full toolkit installation and retry the
+    step that failed (the ``pip install`` for a source build, or the import):
+
+    .. code-block:: bash
+
+        export CUDAToolkit_ROOT=/usr/local/cuda
+        python -c "import openequivariance"
+
+    These configuration steps are required only ONCE after
+    installation (or upgrade) with pip.
 
 
 .. tab:: JAX NVIDIA GPUs 


### PR DESCRIPTION
## What

Adds an installation-docs note that building the C++ extension requires a **full CUDA toolkit including the NVRTC development libraries**, with the exact failure signature and the `CUDAToolkit_ROOT` workaround.

## Why

Follow-up to #207 (item 2 of my 0.6.8 test report there): on a toolchain that provides only the compiler — e.g. conda's `cuda-nvcc` package alone — the CMake build fails with

```
target_link_libraries ... CUDA::nvrtc but the target was not found
```

because `openequivariance/CMakeLists.txt` links `CUDA::nvrtc`. The failure is easy to hit in conda-managed environments (where `cuda-nvcc` is the idiomatic way to get `nvcc`) and the error message doesn't hint at the fix. Verified on torch 2.8.0+cu128 / cp311 / RTX 4060 Ti: setting `CUDAToolkit_ROOT` to a full toolkit (`/usr/local/cuda-12.8`) resolves it.

As suggested by @asglover in #207 — happy to adjust wording or placement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)