### PR TITLE
lru cache for jinja env

### DIFF
--- a/openequivariance/openequivariance/templates/jinja_utils.py
+++ b/openequivariance/openequivariance/templates/jinja_utils.py
@@ -1,3 +1,5 @@
+from functools import lru_cache
+
 from jinja2 import Environment, PackageLoader
 
 
@@ -16,6 +18,7 @@ def sizeof(dtype):
         raise Exception("Provided undefined datatype to sizeof!")
 
 
+@lru_cache(maxsize=2)
 def get_jinja_environment(is_hip=False):
     env = Environment(
         loader=PackageLoader("openequivariance"), extensions=["jinja2.ext.do"]


### PR DESCRIPTION
I was doing a bit of profiling and noticed that getting the env costing a lot and making it so that the there was no template caching. With the lru cache, getting the env is faster and that env has the template cached. All in all it drops the templating cost from ~100 -> ~10 ms each TPP. A small, but not insubstantial speedup. 